### PR TITLE
refactor : 사용자 요청 좌석과 이미 예약된 좌석 비교시 추상화 수준 동일하게

### DIFF
--- a/src/main/java/com/example/demo/service/BookingService.java
+++ b/src/main/java/com/example/demo/service/BookingService.java
@@ -24,7 +24,9 @@ public class BookingService {
 
     public void reserve(String userEmail, List<Integer> requestSeatIds, Long screeningId) throws Exception {
         Screening screening = screeningService.getScreeningById(screeningId);
-        assertSeatsNoConflict(requestSeatIds,screeningId);
+        Set<Integer> reservedSeatIds = reservationService.getReservedSeatIdByScreeningId(screeningId);
+
+        assertSeatsNoConflict(requestSeatIds,reservedSeatIds);
         List<Reservation> reservations = buildReservations(requestSeatIds,screening,userEmail);
         reservationService.reserve(reservations);
     }
@@ -40,8 +42,7 @@ public class BookingService {
                         .toList();
     }
 
-    private void assertSeatsNoConflict(List<Integer> seatIds, Long screeningId) throws Exception {
-        Set<Integer> reservedSeats = reservationService.getReservedSeatIdByScreeningId(screeningId);
+    private void assertSeatsNoConflict(List<Integer> seatIds, Set<Integer> reservedSeats) throws Exception {
         List<Integer> unavailableSeats = seatIds.stream()
                 .filter(reservedSeats::contains)
                 .toList();


### PR DESCRIPTION
### 리팩토링 배경

기존에는 예약 요청 좌석(`requestSeatIds`)과 `screeningId`를 직접 비교하여 좌석 충돌 여부를 확인했지만,
이는 **값(List<Integer>) vs 식별자(Long)** 간의 **추상화 수준이 불일치**한 구조였습니다.

---

### 변경 내용

- 충돌 검증을 다음과 같이 변경하여 추상화 수준을 맞춤:
  `requestSeatIds` vs `screeningId`
  => `requestSeatIds` vs `reservedSeatIds` (이미 예약된 좌석)

=> 비교 함수의 명확성 증가
=> 가독성 증가

