### PR TITLE
refactor : 좌석 현황 반환 메서드 비즈니스 로직으로 DTO 조합

### DIFF
--- a/src/main/java/com/example/demo/service/BookingService.java
+++ b/src/main/java/com/example/demo/service/BookingService.java
@@ -51,23 +51,9 @@ public class BookingService {
             throw new Exception(String.format("이미 예약 되어있는 좌석 : " + unavailableSeats));
     }
 
-    // 역할 : 좌석현황 응답 dto 조합
-    // 고민 : dto에서 한번에 가져올지 아니면 아래 처럼 비즈니스 로직에서 조립하는 방식으로 할지?
-    // 조립 : 모든 좌석 조회 + 예약좌석 조회 => stream()으로 새로운 dto에 담기
-    // dto : 좌석 테이블 join 예약 테이블 => dto에 담기
+    // 유연한 변경을 더 중요시하여 조인 + 서브쿼리 대신 비즈니스 로직으로 SeatStatus를 조합한다.
     public SeatStatusResponseDto getSeatStatus(Long screeningId) {
-        //책임 : 모든 좌석을 가져온다. 예약 좌석을 가져온다. 각 좌석에 상태를 부여한다. 응답 dto를 반환한다.
-        screeningService.assertScreeningExists(screeningId);
-
-        // screening이 존재하는지를 getReservedSeatsIdByScreeingId에서 확인하면 안되는가? -> getReservedSeatsIdByScreeningId에서 예외를 던진다면,
-        // screening 자체가 없는건지 아니면 screening에 대한 예매가 아직 없는건지 불분명확함. 같은 종류의 예외가 발생할 수 있는 곳이 두곳임.
-        // 하지만 이는 예외 분기처리로 가능하다.
-        // 또한 ReservationService에서 불필요한 외부 도메인(ScreeningService)에 의존하게 됨.
-        // ReservationService에서
-        // 재사용성측면에서 어짜피 getReservedSeatIdByScreeningId()를 위해서는 항상 screeningId 존재여부 확인해야함.
-        // 현재 개발 초기이기 때문에 미래에 변경 여부가 엄청 많다. 변경에 대한 대비를 위해 불필요한 의존을 줄이는 것이더 효과적이라고 판단.
-        // 또한 현재까지는 getReservedSeatIdByScreeningId()를 재사용될 경우가 별로 없다고 생각했다.
-        // 따라서 불필요한 의존으로 변경시 영향력이 전파되는 것보다 재사용마다 코드를 작성하는게 더 안전하다고 판단.
+        assertScreeningExists(screeningId);
         Set<Integer> reservedSeatIds = reservationService.getReservedSeatIdByScreeningId(screeningId);
         List<Seat> allSeats = seatService.findAllSeats();
 

--- a/src/main/java/com/example/demo/service/SeatService.java
+++ b/src/main/java/com/example/demo/service/SeatService.java
@@ -23,8 +23,7 @@ public class SeatService {
     }
 
     public List<Seat> findAllSeats(){
-        List<Seat> seats = seatRepository.findAll();
-        return seats;
+        return  seatRepository.findAll();
     }
 
 }


### PR DESCRIPTION
```sql
-- 좌석 + 예약 여부 조회용 서브쿼리 조인 예시
SELECT 
    s.seat_id,
    s.row,
    s.col,
    CASE 
        WHEN r.reservation_id IS NOT NULL THEN TRUE
        ELSE FALSE
    END AS is_reserved
FROM Seat s
LEFT JOIN (
    SELECT * 
    FROM Reservation 
    WHERE screening_id = ?
) r ON s.seat_id = r.seat_id;
```


# 문제점 및 고려사항

- 위 쿼리는 기본적인 "좌석 + 예약 여부" 조회에는 적합함
- 그러나 서비스 변경사항이 자주 발생할 것으로 예상됨



# 예상되는 변경 사항 예시

- 좌석별 가격 정보 추가
  → 별도 가격 테이블 또는 규칙 조인 필요
- 사용자 본인의 예약 여부 표시
  → CASE 절에 r.user_id = :currentUserId 조건 추가 필요
- 할인석 / 장애석 등 좌석 유형 구분 로직
  → SeatType 정보 조인 + 별도 처리 로직 필요


# 결론

- 위 쿼리는 정적이고 단순한 구조에는 적합하지만
- 자주 바뀌는 비즈니스 로직에는 유연성이 떨어짐
- 따라서 유지보수성과 유연성을 고려해, Service Layer에서의 DTO 조합 방식 선택이 더 적합함

