### PR TITLE
Fix/reserve

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'com.github.f4b6a3:uuid-creator:5.3.2'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/com/example/demo/controller/BookingController.java
+++ b/src/main/java/com/example/demo/controller/BookingController.java
@@ -38,7 +38,7 @@ public class BookingController {
     }
 
     @GetMapping("/{movieId}/screenings")
-    public ResponseEntity<?> getScreeningsByMovie(@PathVariable("movieId") Long movieId){
+    public ResponseEntity<?> getScreeningsByMovie(@PathVariable("movieId") Integer movieId){
         try{
             return ResponseEntity.ok(movieScheduleService.getMovieWithSchedules(movieId));
         } catch(Exception e){

--- a/src/main/java/com/example/demo/controller/BookingController.java
+++ b/src/main/java/com/example/demo/controller/BookingController.java
@@ -1,6 +1,6 @@
 package com.example.demo.controller;
 
-import com.example.demo.dto.ReservationReqiestDto;
+import com.example.demo.dto.ReservationRequestDto;
 import com.example.demo.service.BookingService;
 import com.example.demo.service.MovieScheduleService;
 import lombok.RequiredArgsConstructor;
@@ -18,7 +18,7 @@ public class BookingController {
     private final MovieScheduleService movieScheduleService;
 
     @GetMapping("/screenings/{screeningId}/seats")
-    public ResponseEntity<?> getSeatStatus(@PathVariable("screeningId") Long screeningId) {
+    public ResponseEntity<?> getSeatStatus(@PathVariable("screeningId") Integer screeningId) {
         try{
             return ResponseEntity.ok(bookingService.getSeatStatus(screeningId));
         } catch (Exception e){
@@ -28,9 +28,9 @@ public class BookingController {
     }
 
     @PostMapping("/reservations")
-    public ResponseEntity<?> reserve(@RequestBody ReservationReqiestDto request) {
+    public ResponseEntity<?> reserve(@RequestBody ReservationRequestDto request) {
         try{
-            bookingService.reserve(request.getUserEmail(),request.getSeatIds(),request.getScreeningId());
+            bookingService.reserve(request.getUserId(),request.getSeatIds(),request.getScreeningId());
             return ResponseEntity.ok().body(String.format("예매 완료"));
         } catch(Exception e){
             return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());

--- a/src/main/java/com/example/demo/domain/Movie.java
+++ b/src/main/java/com/example/demo/domain/Movie.java
@@ -14,8 +14,12 @@ import lombok.NoArgsConstructor;
 public class Movie {
     @Id
     @GeneratedValue
-    private Long movieId;
+    private Integer movieId;
 
     private String movieName;
     private String runningTime;
+
+    void save(){
+
+    }
 }

--- a/src/main/java/com/example/demo/domain/Reservation.java
+++ b/src/main/java/com/example/demo/domain/Reservation.java
@@ -42,6 +42,4 @@ public class Reservation {
         this.seatId = seatId;
     }
 
-
-
 }

--- a/src/main/java/com/example/demo/domain/Reservation.java
+++ b/src/main/java/com/example/demo/domain/Reservation.java
@@ -6,25 +6,39 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Getter
 @Entity
 @Table(name = "reservation")
 @NoArgsConstructor
 public class Reservation {
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "reservation_id")
     private Long reservationId;
 
-    private String userEmail;
-    private Long movieId;
-    private Long screeningId;
+    @Column(name = "reservation_number")
+    private String reservationNumber;
+    @Column(name = "user_id")
+    private Integer userId;
+    @Column(name = "movie_id")
+    private Integer movieId;
+    @Column(name = "screening_id")
+    private Integer screeningId;
+    @Column(name = "reserved_date")
+    private String reservedDate;
+    @Column(name = "seat_id")
     private Integer seatId;
 
     @Builder
-    public Reservation (String userEmail, Long movieId, Long screeningId, Integer seatId){
-        this.userEmail = userEmail;
+    public Reservation (String reservationNumber,Integer userId, Integer movieId, Integer screeningId,String reservedDate,Integer seatId){
+        this.reservationNumber = reservationNumber;
+        this.userId = userId;
         this.movieId = movieId;
         this.screeningId = screeningId;
+        this.reservedDate = reservedDate;
         this.seatId = seatId;
     }
 

--- a/src/main/java/com/example/demo/domain/Screening.java
+++ b/src/main/java/com/example/demo/domain/Screening.java
@@ -14,10 +14,10 @@ import java.time.LocalDateTime;
 public class Screening {
     @Id
     @GeneratedValue
-    private Long screeningId;
+    private Integer screeningId;
 
     @Column(name = "movieId")
-    private Long movieId;
+    private Integer movieId;
     @Column(name = "startTime")
     private String startTime;
     @Column(name = "endTime")

--- a/src/main/java/com/example/demo/dto/ReservationRequestDto.java
+++ b/src/main/java/com/example/demo/dto/ReservationRequestDto.java
@@ -1,5 +1,6 @@
 package com.example.demo.dto;
 
+import jakarta.persistence.criteria.CriteriaBuilder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -7,8 +8,8 @@ import java.util.List;
 
 @Getter
 @NoArgsConstructor
-public class ReservationReqiestDto {
-    private String userEmail;
+public class ReservationRequestDto {
+    private Integer userId;
     private List<Integer> seatIds;
-    private Long screeningId;
+    private Integer screeningId;
 }

--- a/src/main/java/com/example/demo/dto/SeatStatusResponseDto.java
+++ b/src/main/java/com/example/demo/dto/SeatStatusResponseDto.java
@@ -8,6 +8,6 @@ import java.util.List;
 @Getter
 @AllArgsConstructor
 public class SeatStatusResponseDto {
-    private Long screeningId;
+    private Integer screeningId;
     private List<SeatWithStatusDto> availableSeatWithPrice;
 }

--- a/src/main/java/com/example/demo/repository/MovieRepository.java
+++ b/src/main/java/com/example/demo/repository/MovieRepository.java
@@ -4,5 +4,5 @@ import com.example.demo.domain.Movie;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 
-public interface MovieRepository extends JpaRepository<Movie,Long> {
+public interface MovieRepository extends JpaRepository<Movie,Integer> {
 }

--- a/src/main/java/com/example/demo/repository/MovieScheduleJdbcTemplateRepository.java
+++ b/src/main/java/com/example/demo/repository/MovieScheduleJdbcTemplateRepository.java
@@ -18,7 +18,7 @@ public class MovieScheduleJdbcTemplateRepository implements MovieScheduleReposit
 
 
     @Override
-    public Optional<List<MovieScheduleDto>> findByMovieId(Long movieId) {
+    public Optional<List<MovieScheduleDto>> findByMovieId(Integer movieId) {
         String sql = "SELECT * " +
                 "FROM movie m " +
                 "LEFT JOIN screening s ON m.movie_id = s.movie_id " +

--- a/src/main/java/com/example/demo/repository/MovieScheduleRepository.java
+++ b/src/main/java/com/example/demo/repository/MovieScheduleRepository.java
@@ -7,5 +7,5 @@ import java.util.List;
 import java.util.Optional;
 
 public interface MovieScheduleRepository {
-    Optional<List<MovieScheduleDto>> findByMovieId(Long movieId);
+    Optional<List<MovieScheduleDto>> findByMovieId(Integer movieId);
 }

--- a/src/main/java/com/example/demo/repository/ReservationRepository.java
+++ b/src/main/java/com/example/demo/repository/ReservationRepository.java
@@ -2,14 +2,19 @@ package com.example.demo.repository;
 
 import com.example.demo.domain.Reservation;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.Repository;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 import java.util.Set;
 
 public interface ReservationRepository extends JpaRepository<Reservation,Long> {
-    Set<Integer> findReservedSeatIdByScreeningId(Long screeningId);
-    List<Reservation> findAllByScreeningId(Long screeningId);
-    List<Reservation> findByUserEmail(String userEmail);
+    @Query("SELECT r.seatId FROM Reservation r WHERE r.screeningId = :screeningId")
+    Set<Integer> findReservedSeatIdByScreeningId(@Param("screeningId") Integer screeningId);
+
+    List<Reservation> findAllByScreeningId(Integer screeningId);
+    List<Reservation> findByUserId(Integer userId);
+
 }

--- a/src/main/java/com/example/demo/repository/ScreeningRepository.java
+++ b/src/main/java/com/example/demo/repository/ScreeningRepository.java
@@ -6,11 +6,11 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 import java.util.Optional;
 
-public interface ScreeningRepository extends JpaRepository<Screening,Long> {
+public interface ScreeningRepository extends JpaRepository<Screening,Integer> {
 
     Optional<List<Screening>> findAllByMovieId(Long movieId);
-    boolean existsById(Long screeningId);
-    Optional<Screening> findById(Long screeningId);
+    boolean existsById(Integer screeningId);
+    Optional<Screening> findById(Integer screeningId);
     Screening save(Screening screening);
-    void deleteById(Long screeningId);
+    void deleteById(Integer screeningId);
 }

--- a/src/main/java/com/example/demo/repository/ScreeningRepository.java
+++ b/src/main/java/com/example/demo/repository/ScreeningRepository.java
@@ -8,7 +8,7 @@ import java.util.Optional;
 
 public interface ScreeningRepository extends JpaRepository<Screening,Integer> {
 
-    Optional<List<Screening>> findAllByMovieId(Long movieId);
+    Optional<List<Screening>> findAllByMovieId(Integer movieId);
     boolean existsById(Integer screeningId);
     Optional<Screening> findById(Integer screeningId);
     Screening save(Screening screening);

--- a/src/main/java/com/example/demo/service/BookingService.java
+++ b/src/main/java/com/example/demo/service/BookingService.java
@@ -6,40 +6,30 @@ import com.example.demo.domain.Seat;
 import com.example.demo.dto.SeatStatusResponseDto;
 import com.example.demo.dto.SeatWithStatusDto;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Set;
 
 @Service
 @RequiredArgsConstructor
 public class BookingService {
-    @Autowired
-    private final SeatService seatService;
-    @Autowired
-    private final ReservationService reservationService;
-    @Autowired
-    private final ScreeningService screeningService;
 
-    public void reserve(String userEmail, List<Integer> requestSeatIds, Long screeningId) throws Exception {
+    private final SeatService seatService;
+    private final ReservationService reservationService;
+    private final ScreeningService screeningService;
+    private final ReservationNumberService reservationNumberService;
+
+    public void reserve(Integer userId, List<Integer> requestSeatIds, Integer screeningId) throws Exception {
         Screening screening = screeningService.getScreeningById(screeningId);
         Set<Integer> reservedSeatIds = reservationService.getReservedSeatIdByScreeningId(screeningId);
 
         assertSeatsNoConflict(requestSeatIds,reservedSeatIds);
-        List<Reservation> reservations = buildReservations(requestSeatIds,screening,userEmail);
-        reservationService.reserve(reservations);
-    }
 
-    private static List<Reservation> buildReservations(List<Integer> seatIds, Screening screening,String userEmail) {
-        return seatIds.stream()
-                .map(seatId -> Reservation.builder()
-                        .seatId(seatId)
-                        .userEmail(userEmail)
-                        .screeningId(screening.getScreeningId())
-                        .movieId(screening.getMovieId())
-                        .build())
-                        .toList();
+        List<Reservation> reservations = buildReservations(userId,requestSeatIds,screening);
+        reservationService.saveReservations(reservations);
     }
 
     private void assertSeatsNoConflict(List<Integer> seatIds, Set<Integer> reservedSeats) throws Exception {
@@ -51,9 +41,32 @@ public class BookingService {
             throw new Exception(String.format("이미 예약 되어있는 좌석 : " + unavailableSeats));
     }
 
+    private List<Reservation> buildReservations(Integer userId,List<Integer> seatIds, Screening screening) {
+        String reservedTime = getCurrentTime();
+        String reservationNumber = reservationNumberService.generateReservationNumber(userId,reservedTime,screening.getScreeningId());
+
+        return seatIds.stream()
+                .map(seatId -> Reservation.builder()
+                        .reservationNumber(reservationNumber)
+                        .userId(userId)
+                        .reservedDate(reservedTime)
+                        .seatId(seatId)
+                        .movieId(screening.getMovieId())
+                        .screeningId(screening.getScreeningId())
+                        .build())
+                .toList();
+    }
+
+    private static String getCurrentTime() {
+        LocalDateTime now = LocalDateTime.now();
+        return now.format(DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss"));
+    }
+
+
     // 유연한 변경을 더 중요시하여 조인 + 서브쿼리 대신 비즈니스 로직으로 SeatStatus를 조합한다.
-    public SeatStatusResponseDto getSeatStatus(Long screeningId) {
+    public SeatStatusResponseDto getSeatStatus(Integer screeningId) {
         assertScreeningExists(screeningId);
+
         Set<Integer> reservedSeatIds = reservationService.getReservedSeatIdByScreeningId(screeningId);
         List<Seat> allSeats = seatService.findAllSeats();
 
@@ -61,7 +74,7 @@ public class BookingService {
         return new SeatStatusResponseDto(screeningId, allSeatsWithStatus);
     }
 
-    private void assertScreeningExists(Long screeningId) {
+    private void assertScreeningExists(Integer screeningId) {
         screeningService.getScreeningById(screeningId);
     }
 
@@ -76,6 +89,7 @@ public class BookingService {
                         reservedSeatIds.contains(seat.getSeatId())
                 ))
                 .toList();
+
         return allSeatsWithStatus;
     }
 

--- a/src/main/java/com/example/demo/service/BookingService.java
+++ b/src/main/java/com/example/demo/service/BookingService.java
@@ -24,7 +24,6 @@ public class BookingService {
 
     public void reserve(Integer userId, List<Integer> requestSeatIds, Integer screeningId) throws Exception {
         Screening screening = screeningService.getScreeningById(screeningId);
-        // reservedSeatIds가 없다면 이거에 대해 어떻게 처리할 것인가?
         Set<Integer> reservedSeatIds = reservationService.getReservedSeatIdByScreeningId(screeningId);
 
         assertSeatsNoConflict(requestSeatIds,reservedSeatIds);
@@ -34,6 +33,8 @@ public class BookingService {
     }
 
     private void assertSeatsNoConflict(List<Integer> seatIds, Set<Integer> reservedSeats) throws Exception {
+        if(reservedSeats.isEmpty()) return;
+
         List<Integer> unavailableSeats = seatIds.stream()
                 .filter(reservedSeats::contains)
                 .toList();

--- a/src/main/java/com/example/demo/service/BookingService.java
+++ b/src/main/java/com/example/demo/service/BookingService.java
@@ -24,6 +24,7 @@ public class BookingService {
 
     public void reserve(Integer userId, List<Integer> requestSeatIds, Integer screeningId) throws Exception {
         Screening screening = screeningService.getScreeningById(screeningId);
+        // reservedSeatIds가 없다면 이거에 대해 어떻게 처리할 것인가?
         Set<Integer> reservedSeatIds = reservationService.getReservedSeatIdByScreeningId(screeningId);
 
         assertSeatsNoConflict(requestSeatIds,reservedSeatIds);

--- a/src/main/java/com/example/demo/service/MovieScheduleService.java
+++ b/src/main/java/com/example/demo/service/MovieScheduleService.java
@@ -15,11 +15,11 @@ public class MovieScheduleService {
     private final ScreeningService screeningService;
     private final MovieScheduleRepository movieScheduleRepository;
 
-    public List<Screening> getScheduleByMovieId(Long movieId){
+    public List<Screening> getScheduleByMovieId(Integer movieId){
         return screeningService.getScreeningListByMovieId(movieId);
     }
 
-    public List<MovieScheduleDto> getMovieWithSchedules(Long movieId){
+    public List<MovieScheduleDto> getMovieWithSchedules(Integer movieId){
         return movieScheduleRepository.findByMovieId(movieId)
                 .orElseThrow(() -> new EntityNotFoundException("상영정보 없음"));
     }

--- a/src/main/java/com/example/demo/service/MovieService.java
+++ b/src/main/java/com/example/demo/service/MovieService.java
@@ -11,8 +11,10 @@ import org.springframework.stereotype.Service;
 public class MovieService {
     private final MovieRepository movieRepository;
 
-    public Movie getMovieById(Long movieId){
+    public Movie getMovieById(Integer movieId){
         return movieRepository.findById(movieId).orElseThrow(
                 () -> new EntityNotFoundException("해당 영화 상영정보 없음"));
     }
+
+
 }

--- a/src/main/java/com/example/demo/service/ReservationNumberService.java
+++ b/src/main/java/com/example/demo/service/ReservationNumberService.java
@@ -1,0 +1,18 @@
+package com.example.demo.service;
+
+import com.github.f4b6a3.uuid.UuidCreator;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+@Service
+public class ReservationNumberService {
+    private static final String CHARACTERS = "01346789ABCDFGHJKMNPQRSTUVWXYZ";
+    private static final int LENGTH = 5;
+
+    public String generateReservationNumber(Integer userId, String reservationTime, Integer screeningId ) {
+        String reservationNumber;
+        UUID uuidV7 = UuidCreator.getTimeOrderedEpoch();
+        return uuidV7.toString().substring(0,8);
+    }
+}

--- a/src/main/java/com/example/demo/service/ReservationService.java
+++ b/src/main/java/com/example/demo/service/ReservationService.java
@@ -19,7 +19,6 @@ public class ReservationService {
     private final ScreeningService screeningService;
 
     public Set<Integer> getReservedSeatIdByScreeningId(Integer screeningId){
-        screeningService.getScreeningById(screeningId);
         return reservationRepository.findReservedSeatIdByScreeningId(screeningId);
     }
 

--- a/src/main/java/com/example/demo/service/ReservationService.java
+++ b/src/main/java/com/example/demo/service/ReservationService.java
@@ -18,20 +18,20 @@ public class ReservationService {
     @Autowired
     private final ScreeningService screeningService;
 
-    public Set<Integer> getReservedSeatIdByScreeningId(Long screeningId){
+    public Set<Integer> getReservedSeatIdByScreeningId(Integer screeningId){
         screeningService.getScreeningById(screeningId);
         return reservationRepository.findReservedSeatIdByScreeningId(screeningId);
     }
 
-    public List<Reservation> getUserReservation(String userEmail) {
-        return reservationRepository.findByUserEmail(userEmail);
+    public List<Reservation> getUserReservation(Integer userId) {
+        return reservationRepository.findByUserId(userId);
     }
 
-    public List<Reservation> getAllReservationByScreeningId(Long screeningId){
+    public List<Reservation> getAllReservationByScreeningId(Integer screeningId){
         return reservationRepository.findAllByScreeningId(screeningId);
     }
 
-    public void reserve(List<Reservation> reservations){
+    public void saveReservations(List<Reservation> reservations){
         reservationRepository.saveAll(reservations);
     }
 

--- a/src/main/java/com/example/demo/service/ScreeningService.java
+++ b/src/main/java/com/example/demo/service/ScreeningService.java
@@ -20,12 +20,12 @@ public class ScreeningService {
     @Qualifier("screeningJpaRepository")
     private final ScreeningRepository screeningJpaRepository;
 
-    public Screening getScreeningById(Long screeningId){
+    public Screening getScreeningById(Integer screeningId){
         return screeningJpaRepository.findById(screeningId)
                 .orElseThrow(() -> new EntityNotFoundException(String.format("해당 시간대에 영화 없음")));
     }
 
-    public void assertScreeningExists(Long screeningId){
+    public void assertScreeningExists(Integer screeningId){
         if(screeningJpaRepository.existsById(screeningId))
             throw new EntityNotFoundException(String.format("해당 시간대에 영화 없음"));
     }

--- a/src/main/java/com/example/demo/service/ScreeningService.java
+++ b/src/main/java/com/example/demo/service/ScreeningService.java
@@ -30,7 +30,7 @@ public class ScreeningService {
             throw new EntityNotFoundException(String.format("해당 시간대에 영화 없음"));
     }
 
-    public List<Screening> getScreeningListByMovieId(Long movieId){
+    public List<Screening> getScreeningListByMovieId(Integer movieId){
         return screeningJpaRepository.findAllByMovieId(movieId)
                 .orElseThrow(() -> new EntityNotFoundException(String.format("상영 정보 없음")));
     }

--- a/src/test/java/com/example/demo/service/BookingServiceTest.java
+++ b/src/test/java/com/example/demo/service/BookingServiceTest.java
@@ -44,7 +44,7 @@ public class BookingServiceTest {
 
     // 좌석 1,2,3,4,5 예매 요청, 이미 1,2,3, 예매된 상태 -> 실패 처리
     @Test
-    public void reserveConflictTest() {
+    public void reservationShouldThrowOnSeatConflictTest() {
         //given
         userId = SAMPLE_USER_ID;
         screeningId = SAMPLE_SCREENING_ID;
@@ -88,6 +88,22 @@ public class BookingServiceTest {
 
     }
 
+    // 요청 좌석이 없을 때
+    @Test
+    public void reservationNoRequestSeatIdTest() {
+        //given
+        userId = SAMPLE_USER_ID;
+        screeningId = SAMPLE_SCREENING_ID;
+        movieId = SAMPLE_MOVIE_ID;
+        testScreening = new Screening(screeningId,movieId,"2025-05-24 16:51","2025-05-24 18:51");
+
+        initReservedSeatIds();
+
+        when(screeningService.getScreeningById(anyInt())).thenReturn(testScreening);
+        when(reservationService.getReservedSeatIdByScreeningId(screeningId)).thenReturn(reservedSeatIds);
+
+
+    }
     private void initReservedSeatIds() {
         reservedSeatIds.add(1);
         reservedSeatIds.add(2);

--- a/src/test/java/com/example/demo/service/BookingServiceTest.java
+++ b/src/test/java/com/example/demo/service/BookingServiceTest.java
@@ -1,0 +1,96 @@
+package com.example.demo.service;
+
+
+import com.example.demo.domain.Screening;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class BookingServiceTest {
+    @InjectMocks
+    private BookingService bookingService;
+
+    @Mock
+    private  SeatService seatService;
+    @Mock
+    private ReservationService reservationService;
+    @Mock
+    private ScreeningService screeningService;
+    @Mock
+    private ReservationNumberService reservationNumberService;
+
+    static final int SAMPLE_USER_ID = 1;
+    static final int SAMPLE_SCREENING_ID = 1024;
+    static final int SAMPLE_MOVIE_ID = 4;
+
+    private Screening testScreening;
+    private Integer screeningId;
+    private Integer userId;
+    private Integer movieId;
+    private Set<Integer> reservedSeatIds =  new HashSet<>();
+    private List<Integer> requestSeatIds = new ArrayList<>();
+
+    // 좌석 1,2,3,4,5 예매 요청, 이미 1,2,3, 예매된 상태 -> 실패 처리
+    @Test
+    public void reserveConflictTest() {
+        //given
+        userId = SAMPLE_USER_ID;
+        screeningId = SAMPLE_SCREENING_ID;
+        movieId = SAMPLE_MOVIE_ID;
+        testScreening = new Screening(screeningId,movieId,"2025-05-24 16:51","2025-05-24 18:51");
+
+        initReservedSeatIds();
+        for(int i = 0; i < 5; i++)
+            requestSeatIds.add(i);
+
+        when(screeningService.getScreeningById(anyInt())).thenReturn(testScreening);
+        when(reservationService.getReservedSeatIdByScreeningId(screeningId)).thenReturn(reservedSeatIds);
+
+        //then
+        Exception exception = Assertions.assertThrows(Exception.class,
+                () -> bookingService.reserve(userId, requestSeatIds, screeningId));
+        org.assertj.core.api.Assertions.assertThat(exception.getMessage()).isEqualTo("이미 예약 되어있는 좌석 : " + reservedSeatIds);
+
+    }
+
+    // 요청 좌석 : 4,5 예약 좌석 1,2,3 -> 겹치는 거 없으므로 성공
+    @Test
+    public void reservationSuccessTest() throws Exception {
+        //given
+        userId = SAMPLE_USER_ID;
+        screeningId = SAMPLE_SCREENING_ID;
+        movieId = SAMPLE_MOVIE_ID;
+        testScreening = new Screening(screeningId,movieId,"2025-05-24 16:51","2025-05-24 18:51");
+
+        requestSeatIds.add(4);
+        requestSeatIds.add(5);
+        initReservedSeatIds();
+
+        when(screeningService.getScreeningById(anyInt())).thenReturn(testScreening);
+        when(reservationService.getReservedSeatIdByScreeningId(screeningId)).thenReturn(reservedSeatIds);
+
+        //then
+        Assertions.assertDoesNotThrow(() ->
+                bookingService.reserve(userId,requestSeatIds,screeningId));
+
+
+    }
+
+    private void initReservedSeatIds() {
+        reservedSeatIds.add(1);
+        reservedSeatIds.add(2);
+        reservedSeatIds.add(3);
+    }
+}

--- a/src/test/java/com/example/demo/service/BookingServiceTest.java
+++ b/src/test/java/com/example/demo/service/BookingServiceTest.java
@@ -2,7 +2,9 @@ package com.example.demo.service;
 
 
 import com.example.demo.domain.Screening;
+import org.aspectj.lang.annotation.Before;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -42,14 +44,18 @@ public class BookingServiceTest {
     private Set<Integer> reservedSeatIds =  new HashSet<>();
     private List<Integer> requestSeatIds = new ArrayList<>();
 
-    // 좌석 1,2,3,4,5 예매 요청, 이미 1,2,3, 예매된 상태 -> 실패 처리
-    @Test
-    public void reservationShouldThrowOnSeatConflictTest() {
-        //given
+    @BeforeEach
+    public void setUp() {
         userId = SAMPLE_USER_ID;
         screeningId = SAMPLE_SCREENING_ID;
         movieId = SAMPLE_MOVIE_ID;
         testScreening = new Screening(screeningId,movieId,"2025-05-24 16:51","2025-05-24 18:51");
+
+    }
+    // 좌석 1,2,3,4,5 예매 요청, 이미 1,2,3, 예매된 상태 -> 실패 처리
+    @Test
+    public void reservationShouldThrowOnSeatConflictTest() {
+        //given
 
         initReservedSeatIds();
         for(int i = 0; i < 5; i++)
@@ -69,10 +75,6 @@ public class BookingServiceTest {
     @Test
     public void reservationSuccessTest() throws Exception {
         //given
-        userId = SAMPLE_USER_ID;
-        screeningId = SAMPLE_SCREENING_ID;
-        movieId = SAMPLE_MOVIE_ID;
-        testScreening = new Screening(screeningId,movieId,"2025-05-24 16:51","2025-05-24 18:51");
 
         requestSeatIds.add(4);
         requestSeatIds.add(5);
@@ -92,18 +94,19 @@ public class BookingServiceTest {
     @Test
     public void reservationNoRequestSeatIdTest() {
         //given
-        userId = SAMPLE_USER_ID;
-        screeningId = SAMPLE_SCREENING_ID;
-        movieId = SAMPLE_MOVIE_ID;
-        testScreening = new Screening(screeningId,movieId,"2025-05-24 16:51","2025-05-24 18:51");
 
         initReservedSeatIds();
 
         when(screeningService.getScreeningById(anyInt())).thenReturn(testScreening);
         when(reservationService.getReservedSeatIdByScreeningId(screeningId)).thenReturn(reservedSeatIds);
 
+        //then
+        Assertions.assertDoesNotThrow(() ->
+            bookingService.reserve(userId,requestSeatIds,screeningId));
 
     }
+
+
     private void initReservedSeatIds() {
         reservedSeatIds.add(1);
         reservedSeatIds.add(2);

--- a/src/test/java/com/example/demo/service/MovieScheduleServiceTest.java
+++ b/src/test/java/com/example/demo/service/MovieScheduleServiceTest.java
@@ -15,6 +15,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.when;
 
@@ -30,8 +31,8 @@ public class MovieScheduleServiceTest {
 
     private Movie testMovie;
     private List<Screening> testScreeningList;
-    private Long movieId;
-    private static final Long SAMPLE_MOVIE_ID = 7L;
+    private Integer movieId;
+    private static final Integer SAMPLE_MOVIE_ID = 7;
 
     @BeforeEach
     void setUp() {
@@ -44,8 +45,8 @@ public class MovieScheduleServiceTest {
         movieId = SAMPLE_MOVIE_ID;
         initScreeningListByMovieId(movieId);
 
-        when(movieService.getMovieById(anyLong())).thenReturn(testMovie);
-        when(screeningService.getScreeningListByMovieId(anyLong())).thenReturn(testScreeningList);
+        when(movieService.getMovieById(anyInt())).thenReturn(testMovie);
+        when(screeningService.getScreeningListByMovieId(anyInt())).thenReturn(testScreeningList);
 
         //when
         List<MovieScheduleDto> movieScheduleList = movieScheduleService.getMovieWithSchedules(movieId);
@@ -59,8 +60,8 @@ public class MovieScheduleServiceTest {
     public void getMovieScheduleByMovieIdWhenScheduleIsNull(){
         //given
         movieId = SAMPLE_MOVIE_ID;
-        when(movieService.getMovieById(anyLong())).thenReturn(testMovie);
-        when(screeningService.getScreeningListByMovieId(anyLong())).thenThrow(new EntityNotFoundException("상영정보 없음"));
+        when(movieService.getMovieById(anyInt())).thenReturn(testMovie);
+        when(screeningService.getScreeningListByMovieId(anyInt())).thenThrow(new EntityNotFoundException("상영정보 없음"));
 
         //
         org.junit.jupiter.api.Assertions.assertThrows(EntityNotFoundException.class,
@@ -80,10 +81,10 @@ public class MovieScheduleServiceTest {
         }
     }
 
-    private void initScreeningListByMovieId(Long movieId) {
+    private void initScreeningListByMovieId(Integer movieId) {
         testScreeningList = new ArrayList<>();
-        testScreeningList.add(new Screening(1L, movieId, "10:00", "12:30"));
-        testScreeningList.add(new Screening(2L, movieId, "13:00", "15:30"));
+        testScreeningList.add(new Screening(1, movieId, "10:00", "12:30"));
+        testScreeningList.add(new Screening(2, movieId, "13:00", "15:30"));
 
     }
 }


### PR DESCRIPTION
기존 로직 : 
1. 이미 예약된 좌석 확인
2. 사용자가 요청한 좌석과 충돌 여부 확인
3. 예매
### Issue 1.  reservedSeatIds가 emptyList

요청이 해당 상영정보에 대해 첫번째 예매건이라는 의미이므로 정상흐름이다.

단, 이 상황에서는 assertSeatsNoConflict() 메소드에서 불필요한 연산이 실행되므로 이를 방지할 필요가 있다.

void reserve() 에서 분기처리를 하기에는 추상화 수준이 떨어지고 가독성이 저하된다.

assertSeatsNoConflict() - "검증할 데이터가 없어 의미가 없다"를 판단하는 것 또한 "충돌여부 검증"이라는 역할 안에서 수행해야 할 책임이므로 이 메서드에서 검증하고 reservedSeatIds가 빈 리스트시, 바로 리턴한다.